### PR TITLE
Add SignalHandler::unregister

### DIFF
--- a/src/SignalHandler.php
+++ b/src/SignalHandler.php
@@ -235,7 +235,7 @@ class SignalHandler
     /**
      * @param array $signals array of signal names (more portable) or constants
      * @param LoggerInterface|callable $loggerOrCallback A PSR-3 Logger or a callback($signal, $signalName)
-     * @return SignalHandler A handler on which you can call isTriggered to know if the signal was received, and reset() to forget
+     * @return static A handler on which you can call isTriggered to know if the signal was received, and reset() to forget
      */
     public static function create($signals = null, $loggerOrCallback = null)
     {
@@ -279,6 +279,32 @@ class SignalHandler
         }
 
         return $handler;
+    }
+
+   /**
+     * Clear all previously registered signal handlers.
+     *
+     * @param  string[]|int[]|null $signals
+     * @return void
+     */
+    public function unregister($signals = null)
+    {
+        if (empty($signals)) {
+            $signals = [SIGINT, SIGTERM];
+        }
+
+        foreach ($signals as $signal) {
+            if (is_string($signal)) {
+                // skip missing signals, for example OSX does not have all signals
+                if (!defined($signal)) {
+                    continue;
+                }
+
+                $signal = constant($signal);
+            }
+
+            pcntl_signal($signal, SIG_DFL);
+        }
     }
 
     private static function getSignalName($signo)


### PR DESCRIPTION
Clear all previously registered signal handlers.

```php
$that = $this;

$this->sigHandler = SignalHandler::create(
    [ /* known signals */ ],
    function (int $signal, string $name) use ($that) {
        switch ($signal) {
            case SIGTERM:
                $that->terminate();
                break;
            case SIGINT:
                $that->terminate();
                break;
            case SIGQUIT:
                $that->shutdown();
                break;
            case SIGUSR1:
                $that->kill();
                break;
            case SIGUSR2:
                $this->pause();
                break;
            case SIGCONT:
                $that->unpause();
                break;
        }
    }
);

// ...

$this->sigHandler->unregister([ /* known signals */ ]);
```

---

IMO:
- There is an naming issue. I wold like use `SignalHandler::register` and `SignalHandler::unregister` rather than `SignalHandler::create` and `SignalHandler::unregister`
- I can't find any real need to use static nature of the current `SignalHandler::create`
- The `SignalHandler::create` looks like a factory method but in other hand it also will register handlers. Thus the single responsibility principle is violated here. 