### PR TITLE
Fix flaky Windows test by preloading PHPUnit mock classes

### DIFF
--- a/tests/SignalHandlerTest.php
+++ b/tests/SignalHandlerTest.php
@@ -164,6 +164,12 @@ class SignalHandlerTest extends TestCase
     {
         $log = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
+        // The Windows CTRL handler runs in a separate thread where class autoloading
+        // is unreliable; invoke a throwaway mock here so PHPUnit's mock-invocation
+        // classes (e.g. PHPUnit\Framework\MockObject\Invocation) are loaded in the
+        // main thread first, avoiding a "Class not found" error during dispatch.
+        $this->getMockBuilder(LoggerInterface::class)->getMock()->info('warmup');
+
         $signal = SignalHandler::create([SignalHandler::SIGINT, SignalHandler::SIGBREAK], $log);
         $log->expects(self::atLeastOnce())
             ->method('info')


### PR DESCRIPTION
## Problem

`testLoggingAndDefaultOnWindows` intermittently failed on the `7.4 / windows-latest` job with:

```
Error: Class 'PHPUnit\Framework\MockObject\Invocation' not found
```

It's the only Windows test that drives a **PHPUnit mock** from inside the async Windows CTRL handler (`sapi_windows_generate_ctrl_event`). That handler runs in a separate thread where class autoloading is unreliable, so PHPUnit's lazy load of `MockObject\Invocation` at invocation time occasionally failed. The other Windows tests use a plain closure or no logger, so they never hit this.

## Fix

Invoke a throwaway mock once in the main thread before dispatching the signal, forcing PHPUnit's mock-invocation classes to load process-wide first. Once loaded, they're available to the CTRL-handler thread.

A real `LoggerInterface` test-double isn't an option here: `psr/log` resolves to v1 on PHP 7.4 and v3 on PHP 8+ with incompatible signatures — the mock is what insulates the test from that.

## Verification

Validated across 3 consecutive green CI runs on the previously-flaky `7.4 / windows-latest` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)